### PR TITLE
Update package name in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include requirements.txt
 include LICENSE
 include README.rst
-include try/script.template
+include trypackage/script.template


### PR DESCRIPTION
from `try` to `trypackage`. It looks like the package name change was introduced in edf0430a13183dbe2774ed5214bf9e38214532d1, but MANIFEST.in didn't get updated.

The incorrect package/folder name was causing the `--editor` flag to fail because installations didn't bundle `trypackage/script.template`

Hope this helps, let me know if there's anything else you would like me to do!