### PR TITLE
Use plain python venv instead of virtualenv

### DIFF
--- a/trypackage/core.py
+++ b/trypackage/core.py
@@ -95,7 +95,12 @@ def use_virtualenv(virtualenv, python_version):
             context.virtualenv_path = virtualenv
             yield True
         else:
-            proc = Popen("virtualenv env -p {0} >> {1}".format(python_version, context.logfile),
+            if python_version[0] in ['2', '3']:
+                python_exe = "python{}".format(python_version)
+            else:
+                # Assume python version is actually the executable
+                python_exe = python_version
+            proc = Popen("{0} -m venv env >> {1}".format(python_exe, context.logfile),
                          shell=True, cwd=context.tempdir_path)
             context.virtualenv_path = os.path.join(context.tempdir_path, "env")
             yield proc.wait() == 0

--- a/trypackage/core.py
+++ b/trypackage/core.py
@@ -95,7 +95,7 @@ def use_virtualenv(virtualenv, python_version):
             context.virtualenv_path = virtualenv
             yield True
         else:
-            if python_version[0] in ['2', '3']:
+            if all(map(str.isdecimal, python_version.split("."))):
                 python_exe = "python{}".format(python_version)
             else:
                 # Assume python version is actually the executable


### PR DESCRIPTION
The package was using virtualenv as an unlisted dependency. I'm switching here to using `python -m venv` instead, which appears to be part of the standard library. Without this, `try` is broken for me.